### PR TITLE
feat: add auth and star API routes

### DIFF
--- a/Backend/app/api/auth/login/route.js
+++ b/Backend/app/api/auth/login/route.js
@@ -1,0 +1,29 @@
+import { connectDB } from "@/lib/db";
+import User from "@/models/User";
+import bcrypt from "bcryptjs";
+import { signJwt } from "@/lib/jwt";
+import { okJson, badRequest, methodNotAllowed, corsHeaders } from "@/lib/cors";
+
+export async function OPTIONS() {
+  return new Response(null, { headers: corsHeaders() });
+}
+
+export async function POST(req) {
+  await connectDB();
+  const { email, password } = await req.json();
+  if (!email || !password) return badRequest("email and password required");
+
+  const user = await User.findOne({ email });
+  if (!user || !user.passwordHash) return okJson({ error: "Invalid credentials" }, { status: 401 });
+
+  const ok = await bcrypt.compare(password, user.passwordHash);
+  if (!ok) return okJson({ error: "Invalid credentials" }, { status: 401 });
+
+  const token = signJwt({ sub: user._id.toString(), email: user.email });
+  return okJson({
+    accessToken: token,
+    user: { id: user._id, email: user.email, displayName: user.displayName, avatarUrl: user.avatarUrl },
+  });
+}
+
+export function GET() { return methodNotAllowed(); }

--- a/Backend/app/api/auth/register/route.js
+++ b/Backend/app/api/auth/register/route.js
@@ -1,0 +1,30 @@
+import { connectDB } from "@/lib/db";
+import User from "@/models/User";
+import bcrypt from "bcryptjs";
+import { signJwt } from "@/lib/jwt";
+import { okJson, badRequest, methodNotAllowed, corsHeaders } from "@/lib/cors";
+
+export async function OPTIONS() {
+  return new Response(null, { headers: corsHeaders() });
+}
+
+export async function POST(req) {
+  await connectDB();
+  const { email, password, displayName } = await req.json();
+
+  if (!email || !password) return badRequest("email and password required");
+
+  const exists = await User.findOne({ email });
+  if (exists) return badRequest("Email already in use");
+
+  const hash = await bcrypt.hash(password, 10);
+  const user = await User.create({ email, passwordHash: hash, displayName });
+
+  const token = signJwt({ sub: user._id.toString(), email: user.email });
+  return okJson({
+    accessToken: token,
+    user: { id: user._id, email: user.email, displayName: user.displayName, avatarUrl: user.avatarUrl },
+  });
+}
+
+export function GET() { return methodNotAllowed(); }

--- a/Backend/app/api/stars/[id]/route.js
+++ b/Backend/app/api/stars/[id]/route.js
@@ -1,0 +1,29 @@
+import { connectDB } from "@/lib/db";
+import Star from "@/models/Star";
+import { verifyFromAuthHeader } from "@/lib/jwt";
+import { okJson, badRequest, unauthorized, methodNotAllowed, corsHeaders } from "@/lib/cors";
+
+export async function OPTIONS() {
+  return new Response(null, { headers: corsHeaders() });
+}
+
+export async function PATCH(req, { params }) {
+  await connectDB();
+  const payload = verifyFromAuthHeader(req);
+  if (!payload) return unauthorized();
+
+  const { id } = params;
+  const body = await req.json();
+
+  const star = await Star.findOne({ _id: id, owner: payload.sub });
+  if (!star) return okJson({ error: "Star not found/owned" }, { status: 404 });
+
+  if (body.displayName !== undefined) star.displayName = body.displayName;
+  if (body.certificateStyle) star.certificateStyle = body.certificateStyle;
+
+  await star.save();
+  return okJson(star);
+}
+
+export function GET() { return methodNotAllowed(); }
+export function POST() { return methodNotAllowed(); }

--- a/Backend/app/api/stars/route.js
+++ b/Backend/app/api/stars/route.js
@@ -1,0 +1,43 @@
+import { connectDB } from "@/lib/db";
+import Star from "@/models/Star";
+import { verifyFromAuthHeader } from "@/lib/jwt";
+import { okJson, badRequest, unauthorized, methodNotAllowed, corsHeaders } from "@/lib/cors";
+
+export async function OPTIONS() {
+  return new Response(null, { headers: corsHeaders() });
+}
+
+export async function GET(req) {
+  await connectDB();
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q");
+  const stars = q
+    ? await Star.find({ $text: { $search: q } }).limit(50)
+    : await Star.find().limit(50).sort({ createdAt: -1 });
+  return okJson(stars);
+}
+
+export async function POST(req) {
+  await connectDB();
+  const payload = verifyFromAuthHeader(req);
+  if (!payload) return unauthorized();
+
+  const body = await req.json();
+  if (!body.baseName && !body.displayName) return badRequest("baseName or displayName required");
+
+  const star = await Star.create({
+    owner: payload.sub,
+    baseName: body.baseName,
+    displayName: body.displayName,
+    ra: body.ra,
+    dec: body.dec,
+    magnitude: body.magnitude,
+    constellation: body.constellation,
+    certificateStyle: body.certificateStyle || "classic",
+    catalogId: body.catalogId,
+  });
+
+  return okJson(star);
+}
+
+export function PATCH() { return methodNotAllowed(); }

--- a/Backend/lib/cors.js
+++ b/Backend/lib/cors.js
@@ -1,0 +1,28 @@
+const ALLOW_ORIGIN = "*"; // tighten in prod
+
+export function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": ALLOW_ORIGIN,
+    "Access-Control-Allow-Methods": "GET,POST,PATCH,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+export function okJson(data, init = {}) {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...corsHeaders(), ...(init.headers || {}) },
+  });
+}
+
+export function badRequest(msg) {
+  return okJson({ error: msg }, { status: 400 });
+}
+
+export function unauthorized(msg = "Unauthorized") {
+  return okJson({ error: msg }, { status: 401 });
+}
+
+export function methodNotAllowed() {
+  return okJson({ error: "Method not allowed" }, { status: 405 });
+}

--- a/Backend/lib/db.js
+++ b/Backend/lib/db.js
@@ -1,0 +1,23 @@
+import mongoose from "mongoose";
+
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!MONGODB_URI) {
+  throw new Error("Missing MONGODB_URI in env");
+}
+
+// Next.js hot reload can call this file many times in dev.
+// Use global cache to avoid creating multiple connections.
+let cached = global.mongoose;
+if (!cached) cached = global.mongoose = { conn: null, promise: null };
+
+export async function connectDB() {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose
+      .connect(MONGODB_URI, { serverSelectionTimeoutMS: 15000 })
+      .then((m) => m);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/Backend/lib/jwt.js
+++ b/Backend/lib/jwt.js
@@ -1,0 +1,18 @@
+import jwt from "jsonwebtoken";
+
+const SECRET = process.env.JWT_SECRET;
+
+export function signJwt(payload, expiresIn = "7d") {
+  return jwt.sign(payload, SECRET, { expiresIn });
+}
+
+export function verifyFromAuthHeader(req) {
+  const auth = req.headers.get("authorization") || "";
+  const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  if (!token) return null;
+  try {
+    return jwt.verify(token, SECRET);
+  } catch {
+    return null;
+  }
+}

--- a/Backend/models/Star.js
+++ b/Backend/models/Star.js
@@ -1,0 +1,26 @@
+import mongoose from "mongoose";
+
+const StarSchema = new mongoose.Schema(
+  {
+    catalogId: { type: String, index: true },
+    baseName: String,              // e.g. Vega
+    displayName: String,           // e.g. Nour
+    ra: Number,
+    dec: Number,
+    magnitude: Number,
+    constellation: String,
+    owner: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+    isGifted: { type: Boolean, default: false },
+    certificateStyle: {
+      type: String,
+      enum: ["classic", "modern", "cosmic"],
+      default: "classic",
+    },
+  },
+  { timestamps: true }
+);
+
+StarSchema.index({ owner: 1 });
+StarSchema.index({ displayName: "text", baseName: "text", constellation: "text" });
+
+export default mongoose.models.Star || mongoose.model("Star", StarSchema);

--- a/Backend/models/User.js
+++ b/Backend/models/User.js
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const UserSchema = new mongoose.Schema(
+  {
+    email: { type: String, unique: true, required: true, index: true },
+    passwordHash: { type: String },           // for email/password
+    googleId: { type: String, sparse: true }, // for Google later
+    displayName: { type: String },
+    avatarUrl: { type: String },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.models.User || mongoose.model("User", UserSchema);


### PR DESCRIPTION
## Summary
- add MongoDB connection helper with caching
- define User and Star mongoose models
- add JWT and CORS utilities
- implement auth register/login and star management API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8630f31888330849f7d47709b9ae4